### PR TITLE
Since Foreign Keys can be nullable, support "None" in form field data

### DIFF
--- a/wtfpeewee/fields.py
+++ b/wtfpeewee/fields.py
@@ -354,9 +354,12 @@ class HiddenQueryField(fields.HiddenField):
         return self.data and self.data.get_id()
 
     def process_formdata(self, valuelist):
-        if valuelist:
+        if valuelist and valuelist[0] != 'None':
             self._data = None
             self._formdata = int(valuelist[0])
+        else:
+            self._data = None
+            self._formdata = None
 
 
 class ModelSelectField(SelectQueryField):


### PR DESCRIPTION
Right now the Ajax popup for foreign keys with foreign_key_lookups defined won't allow "None" to save. This adds support for "None" as a valid value.

Not sure if this is the way you would do it though.

I also made a change to flask-peewee to show "None" as an option in the list in the ajax popup that I can send a pull request for.
