### PR TITLE
If for some reason there is not conversion for a field raise an exception.

### DIFF
--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -103,6 +103,8 @@ class ModelConverter(object):
 
             return field.name, self.defaults[field_class](**kwargs)
 
+        raise AttributeError('There is not possible conversion for \'%s\'' % type(field))
+
 
 def model_fields(model, allow_pk=False, only=None, exclude=None, field_args=None, converter=None):
     """


### PR DESCRIPTION
Otherwise the caller receives a None and some weird error can appear
at random location.

I tried to implement a custom field in peewee but when I use it in the admin interface a strange exception is raised:

```
TypeError: 'NoneType' object is not iterable
```

at the following location

``` python
 field_name, form_field = self.model_converter.convert(field.model_class, field, None)
```

since the method return a `None` value that can't be unpacked in the tuple on the left side.

I think it's more robust to indicate clearly that some unexpected is happened. What do you think?
