### PR TITLE
Make python 3 compatible 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     zip_safe=False,
     platforms='any',
     install_requires=[
-        'peewee>=2.0.0', 'six', 'wtforms',
+        'peewee>=2.0.0', 'wtforms',
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/wtfpeewee/_compat.py
+++ b/wtfpeewee/_compat.py
@@ -1,0 +1,15 @@
+import sys
+
+
+PY2 = sys.version_info[0] == 2
+
+if PY2:
+    text_type = unicode
+    string_types = (str, unicode)
+    unichr = unichr
+    reduce = reduce
+else:
+    text_type = str
+    string_types = (str,)
+    unichr = chr
+    from functools import reduce

--- a/wtfpeewee/fields.py
+++ b/wtfpeewee/fields.py
@@ -6,12 +6,11 @@ import datetime
 import operator
 import warnings
 
-import six
 from wtforms import fields, form, widgets
 from wtforms.fields import FormField, _unset_value
 from wtforms.validators import ValidationError
 from wtforms.widgets import HTMLString, html_params
-
+from wtfpeewee._compat import text_type
 
 __all__ = (
     'ModelSelectField', 'ModelSelectMultipleField', 'ModelHiddenField',
@@ -151,7 +150,7 @@ class SelectChoicesField(fields.SelectField):
     widget = ChosenSelectWidget()
 
     # all of this exists so i can get proper handling of None
-    def __init__(self, label=None, validators=None, coerce=six.text_type, choices=None, allow_blank=False, blank_text=u'', **kwargs):
+    def __init__(self, label=None, validators=None, coerce=text_type, choices=None, allow_blank=False, blank_text=u'', **kwargs):
         super(SelectChoicesField, self).__init__(label, validators, coerce, choices, **kwargs)
         self.allow_blank = allow_blank
         self.blank_text = blank_text or '----------------'
@@ -217,7 +216,7 @@ class SelectQueryField(fields.SelectFieldBase):
         self._set_data(None)
 
         if get_label is None:
-            self.get_label = lambda o: six.text_type(o)
+            self.get_label = lambda o: text_type(o)
         elif isinstance(get_label, basestring):
             self.get_label = operator.attrgetter(get_label)
         else:
@@ -321,7 +320,7 @@ class HiddenQueryField(fields.HiddenField):
         self._set_data(None)
 
         if get_label is None:
-            self.get_label = lambda o: six.text_type(o)
+            self.get_label = lambda o: text_type(o)
         elif isinstance(get_label, basestring):
             self.get_label = operator.attrgetter(get_label)
         else:

--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -13,7 +13,7 @@ from wtfpeewee.fields import SelectChoicesField
 from wtfpeewee.fields import WPDateField
 from wtfpeewee.fields import WPDateTimeField
 from wtfpeewee.fields import WPTimeField
-import six
+from wtfpeewee._compat import text_type
 
 from peewee import BigIntegerField
 from peewee import BlobField
@@ -63,11 +63,11 @@ class ModelConverter(object):
     }
     coerce_defaults = {
         BigIntegerField: int,
-        CharField: six.text_type,
+        CharField: text_type,
         DoubleField: float,
         FloatField: float,
         IntegerField: int,
-        TextField: six.text_type,
+        TextField: text_type,
     }
     required = (
         CharField,

--- a/wtfpeewee/tests.py
+++ b/wtfpeewee/tests.py
@@ -2,14 +2,14 @@ import datetime
 import unittest
 
 from peewee import *
-import six
 from wtforms import fields as wtfields
 from wtforms.form import Form as WTForm
 from wtfpeewee.fields import *
 from wtfpeewee.orm import model_form
+from wtfpeewee._compat import PY2
 
 
-if six.PY3:
+if not PY2:
     implements_to_string = lambda x: x
 else:
     def implements_to_string(cls):


### PR DESCRIPTION
Here are a few specific fixes to make wtf-peewee work with Python 3.  Some possible improvements include using a custom compatibility module instead of a dependency on the six library.
