### PR TITLE
Add Travis config and Fix empty string test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
 install: "pip install peewee wtforms"
 script: "python runtests.py"

--- a/wtfpeewee/tests.py
+++ b/wtfpeewee/tests.py
@@ -345,7 +345,9 @@ class WTFPeeweeTestCase(unittest.TestCase):
 
         # again, this is for the purposes of documenting behavior -- nullable
         # booleanfields won't work without a custom field class
-        self.assertEqual(nfm.b, True)
+        # Passing an empty string will evalute to False
+        # https://bitbucket.org/simplecodes/wtforms/commits/35c5f7182b7f0c62a4d4db7a1ec8719779b4b018
+        self.assertEqual(nfm.b, False)
 
         form = NullFieldsModelForm(FakePost({'c': 'test'}))
         self.assertTrue(form.validate())


### PR DESCRIPTION
Travis config is working (https://travis-ci.org/bndr/wtf-peewee)

There was a change on how wtforms handles the empty string https://bitbucket.org/simplecodes/wtforms/commits/35c5f7182b7f0c62a4d4db7a1ec8719779b4b018
