### PR TITLE
Prevent validators from getting inserted twice

### DIFF
--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -4,6 +4,7 @@ Tools for generating forms based on Peewee models
 """
 
 from collections import namedtuple
+from copy import deepcopy
 from wtforms import Form
 from wtforms import fields as f
 from wtforms import validators
@@ -103,7 +104,7 @@ class ModelConverter(object):
             'default': field.default,
             'description': field.help_text}
         if field_args:
-            kwargs.update(field_args)
+            kwargs.update(deepcopy(field_args))
 
         if field.null:
             # Treat empty string as None when converting.


### PR DESCRIPTION
Related to this flask-admin issue: https://github.com/flask-admin/flask-admin/issues/1094

If you override ```field_args``` with your own dict, the changes made to ```kwargs``` in ```convert()``` will also be made to the dict you used to override ```field_args```. The objects that get copied to ```kwargs``` from ```field_args``` are only references, so you need to deepcopy to prevent the issue.