### PR TITLE
Allow custom-defined Peewee fields to specify default form field

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ to create a form for the Entry model:
 ```python
 from peewee import *
 from wtfpeewee.orm import model_form
+import wtforms
+
+class PasswordField(TextField):
+    """ Custom-defined field example. """
+    def wtf_field(self, model, **kwargs):
+        return wtforms.PasswordField(**kwargs)
 
 class Blog(Model):
     name = CharField()
@@ -21,6 +27,7 @@ class Entry(Model):
     blog = ForeignKeyField(Blog)
     title = CharField()
     body = TextField()
+    protected = PasswordField()
 
     def __unicode__(self):
         return self.title


### PR DESCRIPTION
Making it so that code which calls model_form() doesn't have to have special cases -- this can feel painful when model_form() is called for the same peewee.Model from multiple places, or when called in a generic context which the end-developer has less control over, such as via flask-admin.

If you don't like this as-is, let me know and I'm happy to tweak as necessary.