### PR TITLE
Fix WTForms 3.0 deprecation warnings

### DIFF
--- a/wtfpeewee/fields.py
+++ b/wtfpeewee/fields.py
@@ -52,7 +52,7 @@ class BooleanSelectField(fields.SelectFieldBase):
                 raise ValueError(self.gettext(u'Invalid Choice: could not coerce'))
 
 
-class WPTimeField(StaticAttributesMixin, fields.TextField):
+class WPTimeField(StaticAttributesMixin, fields.StringField):
     attributes = {'class': 'time-widget'}
     formats = ['%H:%M:%S', '%H:%M']
 

--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -56,15 +56,15 @@ class ModelConverter(object):
         (AutoField, f.HiddenField),
         (BigIntegerField, f.IntegerField),
         (DoubleField, f.FloatField),
-        (IPField, f.TextField),
+        (IPField, f.StringField),
         (SmallIntegerField, f.IntegerField),
         (TimestampField, WPDateTimeField),
 
         # Base-classes.
-        (BareField, f.TextField),
+        (BareField, f.StringField),
         (BlobField, f.TextAreaField),
         (BooleanField, f.BooleanField),
-        (CharField, f.TextField),
+        (CharField, f.StringField),
         (DateField, WPDateField),
         (DateTimeField, WPDateTimeField),
         (DecimalField, f.DecimalField),
@@ -72,7 +72,7 @@ class ModelConverter(object):
         (IntegerField, f.IntegerField),
         (TextField, f.TextAreaField),
         (TimeField, WPTimeField),
-        (UUIDField, f.TextField),
+        (UUIDField, f.StringField),
     ))
     coerce_defaults = {
         BigIntegerField: int,

--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -136,7 +136,7 @@ class ModelConverter(object):
             kwargs['validators'].append(validators.Optional())
         else:
             if isinstance(field, self.required):
-                kwargs['validators'].append(validators.Required())
+                kwargs['validators'].append(validators.DataRequired())
 
         if field.name in self.overrides:
             return FieldInfo(field.name, self.overrides[field.name](**kwargs))

--- a/wtfpeewee/tests.py
+++ b/wtfpeewee/tests.py
@@ -208,7 +208,7 @@ class WTFPeeweeTestCase(unittest.TestCase):
     def test_blog_form(self):
         form = BlogForm()
         self.assertEqual(list(form._fields.keys()), ['title'])
-        self.assertTrue(isinstance(form.title, wtfields.TextField))
+        self.assertTrue(isinstance(form.title, wtfields.StringField))
         self.assertEqual(form.data, {'title': None})
 
     def test_entry_form(self):
@@ -218,7 +218,7 @@ class WTFPeeweeTestCase(unittest.TestCase):
         self.assertTrue(isinstance(form.blog, ModelSelectField))
         self.assertTrue(isinstance(form.content, wtfields.TextAreaField))
         self.assertTrue(isinstance(form.pub_date, WPDateTimeField))
-        self.assertTrue(isinstance(form.title, wtfields.TextField))
+        self.assertTrue(isinstance(form.title, wtfields.StringField))
 
         self.assertEqual(form.title.label.text, 'Wacky title')
         self.assertEqual(form.blog.label.text, 'Blog')
@@ -417,7 +417,7 @@ class WTFPeeweeTestCase(unittest.TestCase):
     def test_hidden_field(self):
         class TestEntryForm(WTForm):
             blog = HiddenQueryField(query=Blog.select())
-            title = wtfields.TextField()
+            title = wtfields.StringField()
             content = wtfields.TextAreaField()
 
         form = TestEntryForm(FakePost({


### PR DESCRIPTION
These commits fix two DeprecationWarnings raised by WTForms when running unittests -v :

* DeprecationWarning: The TextField alias for StringField has been deprecated and will be removed in WTForms 3.0
* DeprecationWarning: Required is going away in WTForms 3.0, use DataRequired