### PR TITLE
optional if 1) null=True or 2) has a default value or 3) can be blank…

### DIFF
--- a/wtfpeewee/orm.py
+++ b/wtfpeewee/orm.py
@@ -141,12 +141,13 @@ class ModelConverter(object):
             # Treat empty string as None when converting.
             kwargs['filters'].append(handle_null_filter)
 
-        if (field.null or (field.default is not None)) and not field.choices:
+        if (field.null or (field.default is not None)) or (
+                field.choices and any(not (v) for v, _ in field.choices)):
             # We allow the field to be optional if:
             # 1. the field is null=True and can be blank.
             # 2. the field has a default value.
             kwargs['validators'].append(validators.Optional())
-        elif not field.choices or all(v for v, _ in field.choices):
+        else:
             kwargs['validators'].append(ValueRequired())
 
         if field.name in self.overrides:

--- a/wtfpeewee/tests.py
+++ b/wtfpeewee/tests.py
@@ -208,13 +208,19 @@ class WTFPeeweeTestCase(unittest.TestCase):
         self.assertFalse(form.validate())
         self.assertTrue(list(form.errors), ['status'])
 
-        # This is a change -- although the status field is null=True, since it
-        # defines choices=(...) then the user must select something.
+        # Nullable field with choices:
         choices_obj.status = None
         form = ChoicesForm(obj=choices_obj)
         self.assertEqual(form.status.data, None)
+        self.assertTrue(form.validate())
+        self.assertFalse(list(form.errors), ['status'])
+
+        # Not-nullable field with choices:
+        choices_obj.gender = None
+        form = ChoicesForm(obj=choices_obj)
+        self.assertEqual(form.status.data, None)
         self.assertFalse(form.validate())
-        self.assertTrue(list(form.errors), ['status'])
+        self.assertTrue(list(form.errors), ['gender'])
 
     def test_blank_choices(self):
         obj = BlankChoices(status=None)


### PR DESCRIPTION
The model field gets mapped to an optional field (issue #48) if:

- the field is `null=True` **OR** can be blank.
- the field is null=True and can be blank.
 
